### PR TITLE
Update nuxt to v2.15.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "serve": "nuxt serve"
   },
   "dependencies": {
-    "nuxt": "^2.13.0",
+    "nuxt": "^2.15.8",
     "serve": "^11.3.2"
   },
   "devDependencies": {}


### PR DESCRIPTION
This repo uses `nuxt v2.13.0` which causes error `ERR_OSSL_EVP_UNSUPPORTED` on `Node v20.x`

This PR fixes this by updating nuxt to v2.15.8